### PR TITLE
Make src/ the main input files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
   },
   "homepage": "https://github.com/bayesjs/bayesjs#readme",
   "dependencies": {
-    "@types/round-to": "^4.0.0",
-    "@types/timsort": "^0.3.0",
     "round-to": "^4.1.0",
     "timsort": "^0.3.0",
     "ts-loader": "^6.2.2"
@@ -66,6 +64,8 @@
     "@types/jest": "^24.0.13",
     "@types/node": "^12.12.14",
     "@types/ramda": "0.27.3",
+    "@types/round-to": "^4.0.0",
+    "@types/timsort": "^0.3.0",
     "@typescript-eslint/eslint-plugin": "^2.10.0",
     "@typescript-eslint/parser": "^2.10.0",
     "commitizen": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@parties/bayesjs",
+  "name": "bayesjs",
   "version": "0.6.3",
   "description": "Inference on Bayesian Networks",
   "main": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "bayesjs",
+  "name": "@parties/bayesjs",
   "version": "0.6.3",
   "description": "Inference on Bayesian Networks",
-  "main": "dist/bayes.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
   "files": [
-    "dist"
+    "src"
   ],
   "engines": {
     "node": ">= 10.18",


### PR DESCRIPTION
This changes the `files` field in `package.json` to reference `src/` instead of `dist/`; this is so that the package can be installed directly from git into another NPM package.