### PR TITLE
Fix Asia network bug reported by flipdav8

### DIFF
--- a/models/asia.ts
+++ b/models/asia.ts
@@ -1,0 +1,131 @@
+import { INode, ICptWithParents, ICptWithoutParents } from '../src/types'
+
+export const VisitToAsia: INode = {
+  id: 'VisitToAsia',
+  states: ['T', 'F'],
+  parents: [],
+  cpt: { F: 0.99, T: 0.01 },
+}
+
+export const Tuberculosis: INode = {
+  id: 'Tuberculosis',
+  states: ['T', 'F'],
+  parents: ['VisitToAsia'],
+  cpt: [
+    { when: { VisitToAsia: 'F' }, then: { F: 0.99, T: 0.01 } },
+    { when: { VisitToAsia: 'T' }, then: { F: 0.95, T: 0.05 } },
+  ],
+}
+
+export const Smoker: INode = {
+  id: 'Smoker',
+  states: ['T', 'F'],
+  parents: [],
+  cpt: { F: 0.5, T: 0.5 },
+}
+
+export const LungCancer: INode = {
+  id: 'LungCancer',
+  states: ['T', 'F'],
+  parents: ['Smoker'],
+  cpt: [
+    { when: { Smoker: 'F' }, then: { F: 0.99, T: 0.01 } },
+    { when: { Smoker: 'T' }, then: { F: 0.9, T: 0.1 } },
+  ],
+}
+
+export const TbOrCa = {
+  id: 'TbOrCa',
+  states: ['T', 'F'],
+  parents: ['Tuberculosis', 'LungCancer'],
+  cpt: [
+    {
+      when: { Tuberculosis: 'F', LungCancer: 'F' },
+      then: { F: 1, T: 0 },
+    },
+    {
+      when: { Tuberculosis: 'F', LungCancer: 'T' },
+      then: { F: 0, T: 1 },
+    },
+    {
+      when: { Tuberculosis: 'T', LungCancer: 'F' },
+      then: { F: 0, T: 1 },
+    },
+    {
+      when: { Tuberculosis: 'T', LungCancer: 'T' },
+      then: { F: 0, T: 1 },
+    },
+  ],
+}
+
+export const AbnormalXRay: INode = {
+  id: 'AbnormalXRay',
+  states: ['T', 'F'],
+  parents: ['TbOrCa'],
+  cpt: [
+    { when: { TbOrCa: 'F' }, then: { F: 0.95, T: 0.05 } },
+    {
+      when: { TbOrCa: 'T' },
+      then: { F: 0.02, T: 0.98 },
+    },
+  ],
+}
+
+export const Bronchitis: INode = {
+  id: 'Bronchitis',
+  states: ['T', 'F'],
+  parents: ['Smoker'],
+  cpt: [
+    { when: { Smoker: 'F' }, then: { F: 0.7, T: 0.3 } },
+    { when: { Smoker: 'T' }, then: { F: 0.4, T: 0.6 } },
+  ],
+}
+
+export const Dyspnea = {
+  id: 'Dyspnea',
+  states: ['T', 'F'],
+  parents: ['TbOrCa', 'Bronchitis'],
+  cpt: [
+    {
+      when: { TbOrCa: 'F', Bronchitis: 'F' },
+      then: { F: 0.9, T: 0.1 },
+    },
+    {
+      when: { TbOrCa: 'F', Bronchitis: 'T' },
+      then: { F: 0.2, T: 0.8 },
+    },
+    {
+      when: { TbOrCa: 'T', Bronchitis: 'F' },
+      then: { F: 0.3, T: 0.7 },
+    },
+    {
+      when: { TbOrCa: 'T', Bronchitis: 'T' },
+      then: { F: 0.1, T: 0.9 },
+    },
+  ],
+}
+
+export const allNodes = [
+  VisitToAsia,
+  Tuberculosis,
+  Smoker,
+  LungCancer,
+  TbOrCa,
+  AbnormalXRay,
+  Bronchitis,
+  Dyspnea,
+]
+export const network: {
+  [name: string]: {
+    levels: string[];
+    parents: string[];
+    cpt?: ICptWithParents | ICptWithoutParents;
+  };
+} = {}
+allNodes.forEach((node: INode) => {
+  network[node.id] = {
+    levels: node.states,
+    parents: node.parents,
+    cpt: node.cpt,
+  }
+})

--- a/src/inferences/junctionTree/index.ts
+++ b/src/inferences/junctionTree/index.ts
@@ -2,17 +2,19 @@ import {
   ICombinations,
   IInfer,
   INetwork,
+  ICptWithParents,
+  ICptWithoutParents,
 } from '../../types'
 
-import { LazyPropagationEngine, Distribution, fromCPT } from '../../engines'
+import { LazyPropagationEngine } from '../../engines'
 
 export const infer: IInfer = (network: INetwork, nodes: ICombinations, given: ICombinations = {}): number => {
-  const net: { [name: string]: { levels: string[]; parents: string[]; distribution?: Distribution}} = {}
+  const net: { [name: string]: { levels: string[]; parents: string[]; cpt?: ICptWithParents | ICptWithoutParents}} = {}
   Object.values(network).forEach(node => {
     net[node.id] = {
       levels: node.states,
       parents: node.parents,
-      distribution: fromCPT(node.id, node.cpt),
+      cpt: node.cpt,
     }
   })
   const engine = new LazyPropagationEngine(net)

--- a/test/distributions/fromCPT.test.ts
+++ b/test/distributions/fromCPT.test.ts
@@ -4,7 +4,7 @@ import { fromCPT } from '../../src/engines'
 
 describe('fromCPT', () => {
   it('encodes the correct joint distribution without parents', () => {
-    const dist = fromCPT('Foo', { bar: 10, baz: 90 })
+    const dist = fromCPT('Foo', [], [['bar', 'baz']], { bar: 10, baz: 90 })
     const json = dist.toJSON()
     expect(json.numberOfHeadVariables).toEqual(1)
     expect(json.variableNames).toEqual(['Foo'])
@@ -12,7 +12,7 @@ describe('fromCPT', () => {
     expect(json.potentialFunction).toEqual([0.1, 0.9])
   })
   it('encodes the correct joint distribution with parents', () => {
-    const dist = fromCPT('Foo', [
+    const dist = fromCPT('Foo', ['animal', 'color'], [['bar', 'baz'], ['cat', 'dog'], ['black', 'white', 'brown']], [
       { when: { animal: 'cat', color: 'black' }, then: { bar: 10, baz: 90 } },
       { when: { animal: 'cat', color: 'white' }, then: { bar: 70, baz: 30 } },
       { when: { animal: 'dog', color: 'black' }, then: { bar: 80, baz: 20 } },

--- a/test/inference-engines/alarm.test.ts
+++ b/test/inference-engines/alarm.test.ts
@@ -146,7 +146,7 @@ const infersAlarmGiveMaryCallsFalse = (engine: IInferenceEngine) => {
 }
 
 const infersSetDistribution = (engine: IInferenceEngine) => {
-  engine.setDistribution(fromCPT('BURGLARY', { T: 0.05, F: 0.95 }))
+  engine.setDistribution(fromCPT('BURGLARY', [], [['T', 'F']], { T: 0.05, F: 0.95 }))
   const { infer } = engine
 
   expect(infer({ BURGLARY: ['T'] }).toFixed(4)).toBe('0.0178')

--- a/test/inference-engines/asia.test.ts
+++ b/test/inference-engines/asia.test.ts
@@ -1,0 +1,81 @@
+import * as expect from 'expect'
+
+import { network } from '../../models/asia'
+import { InferenceEngine } from '../../src/index'
+import roundTo = require('round-to')
+
+describe('Asia Network', () => {
+  describe('without evidence, marginal distribution', () => {
+    const engine = new InferenceEngine(network)
+    const infer = (event: Record<string, string[]>) => roundTo(engine.infer(event), 4)
+    it('is infered correctly for Visit to Asia', () => {
+      expect(infer({ VisitToAsia: ['T'] })).toEqual(0.01)
+      expect(infer({ VisitToAsia: ['F'] })).toEqual(0.99)
+    })
+    it('is infered correctly for Tuberculosis', () => {
+      expect(infer({ Tuberculosis: ['T'] })).toEqual(0.0104)
+      expect(infer({ Tuberculosis: ['F'] })).toEqual(0.9896)
+    })
+    it('is infered correctly for Smoker', () => {
+      expect(infer({ Smoker: ['T'] })).toEqual(0.5)
+      expect(infer({ Smoker: ['F'] })).toEqual(0.5)
+    })
+    it('is infered correctly for LungCancer', () => {
+      expect(infer({ LungCancer: ['T'] })).toEqual(0.055)
+      expect(infer({ LungCancer: ['F'] })).toEqual(0.945)
+    })
+    it('is infered correctly for TbOrCa', () => {
+      expect(infer({ TbOrCa: ['T'] })).toEqual(0.0648)
+      expect(infer({ TbOrCa: ['F'] })).toEqual(0.9352)
+    })
+    it('is infered correctly for AbnormalXRay', () => {
+      expect(infer({ AbnormalXRay: ['T'] })).toEqual(0.1103)
+      expect(infer({ AbnormalXRay: ['F'] })).toEqual(0.8897)
+    })
+    it('is infered correctly for Bronchitis', () => {
+      expect(infer({ Bronchitis: ['T'] })).toEqual(0.45)
+      expect(infer({ Bronchitis: ['F'] })).toEqual(0.55)
+    })
+    it('is infered correctly for Dyspnea', () => {
+      expect(infer({ Dyspnea: ['T'] })).toEqual(0.4360)
+      expect(infer({ Dyspnea: ['F'] })).toEqual(0.5640)
+    })
+  })
+  describe('with evidence, marginal distribution', () => {
+    const engine = new InferenceEngine(network)
+    engine.setEvidence({ VisitToAsia: ['T'] })
+    const infer = (event: Record<string, string[]>) => roundTo(engine.infer(event), 4)
+    it('is infered correctly for Visit to Asia', () => {
+      expect(infer({ VisitToAsia: ['T'] })).toEqual(1)
+      expect(infer({ VisitToAsia: ['F'] })).toEqual(0)
+    })
+    it('is infered correctly for Tuberculosis', () => {
+      expect(infer({ Tuberculosis: ['T'] })).toEqual(0.05)
+      expect(infer({ Tuberculosis: ['F'] })).toEqual(0.95)
+    })
+    it('is infered correctly for Smoker', () => {
+      expect(infer({ Smoker: ['T'] })).toEqual(0.5)
+      expect(infer({ Smoker: ['F'] })).toEqual(0.5)
+    })
+    it('is infered correctly for LungCancer', () => {
+      expect(infer({ LungCancer: ['T'] })).toEqual(0.055)
+      expect(infer({ LungCancer: ['F'] })).toEqual(0.945)
+    })
+    it('is infered correctly for TbOrCa', () => {
+      expect(infer({ TbOrCa: ['T'] })).toEqual(0.1023)
+      expect(infer({ TbOrCa: ['F'] })).toEqual(0.8977)
+    })
+    it('is infered correctly for AbnormalXRay', () => {
+      expect(infer({ AbnormalXRay: ['T'] })).toEqual(0.1451)
+      expect(infer({ AbnormalXRay: ['F'] })).toEqual(0.8549)
+    })
+    it('is infered correctly for Bronchitis', () => {
+      expect(infer({ Bronchitis: ['T'] })).toEqual(0.45)
+      expect(infer({ Bronchitis: ['F'] })).toEqual(0.55)
+    })
+    it('is infered correctly for Dyspnea', () => {
+      expect(infer({ Dyspnea: ['T'] })).toEqual(0.4501)
+      expect(infer({ Dyspnea: ['F'] })).toEqual(0.5499)
+    })
+  })
+})

--- a/test/inference-engines/getDistribution.test.ts
+++ b/test/inference-engines/getDistribution.test.ts
@@ -10,7 +10,7 @@ describe('getDistribution', () => {
     const name = 'node3'
     const observed = engine.getDistribution(name).toJSON()
     const cpt = network[name]?.cpt as ICptWithParents | ICptWithoutParents
-    const expected = fromCPT('node3', cpt).toJSON()
+    const expected = fromCPT('node3', [], [['T', 'F']], cpt).toJSON()
     expect(observed.numberOfHeadVariables).toEqual(expected.numberOfHeadVariables)
     expect(observed.variableNames).toEqual(expected.variableNames)
     expect(observed.variableLevels).toEqual(expected.variableLevels)

--- a/test/utils/inferAll.test.ts
+++ b/test/utils/inferAll.test.ts
@@ -16,7 +16,7 @@ describe('InferAll Utils', () => {
       engine.inferAll() // infer to cache
 
       // change network by mutation
-      engine.setDistribution(fromCPT('JOHN_CALLS', [
+      engine.setDistribution(fromCPT('JOHN_CALLS', ['ALARM'], [['T', 'F'], ['T', 'F']], [
         { when: { ALARM: 'T' }, then: { T: 0.1, F: 0.9 } },
         { when: { ALARM: 'F' }, then: { T: 0.95, F: 0.05 } },
       ]))
@@ -52,7 +52,7 @@ describe('InferAll Utils', () => {
         describe('No evidences', () => {
           it("returns inference result for all node's state", () => {
             engine.removeAllEvidence()
-            engine.setDistribution(fromCPT('JOHN_CALLS', network.JOHN_CALLS.cpt as ICptWithParents))
+            engine.setDistribution(fromCPT('JOHN_CALLS', ['ALARM'], [['T', 'F'], ['T', 'F']], network.JOHN_CALLS.cpt as ICptWithParents))
 
             expect(engine.inferAll({ precision: 4 })).toEqual({
               BURGLARY: { T: 0.001, F: 0.999 },


### PR DESCRIPTION
There were two errors in the Asia network construction that led to this failure:
1) Whenever a clique of the junction tree had no factors assigned to it, then it would assign a reference to an invalid formula as the prior distribution for the clique.   The expected behavior is to use the Unit distribution for the prior of the clique.
2) The "fromCPT" function did not preserve the ordering of the variables or their levels relative to the fast nodes in the network.   This lead to the wrong distribution being constructed for nodes when CPTs were provided to the network constructor.   

#### What does this PR do?
This PR fixes the two bugs mentioned above, updates the unit tests.   It also adds the Asia model and some tests to evidence that this bug has been resolved.

#### Where should the reviewer start?
The two major areas of change are the "fromCPT" function in the Distribution.ts module, and the evaluate function in the utils module.   These are good places to start

#### What testing has been done on this PR?
All unit tests have been updated and pass.   An additional unit test for inference on the Asia network has been added to evidence the resolution of this bug.

#### How should this be manually tested?
Try this with other network that you usually use for testing.
1) Verify that the inferences that you get back from the inference engine are correct
2) Use the engine.getDistribution(variableName).describe() method to inspect the conditional distributions on the variables in your network.   Confirm that the description matches what you expect.

#### Any background context you want to provide?
None

#### What are the relevant issues?
This bug was communicated by @flipdav8 on the bayesjs/bayesjs repository.   No issue was created for this bug because it had not yet been discovered in that codebase.

#### Screenshots (if appropriate)
N/A
