### PR TITLE
feat(sampling): initial implementation of random sampling

### DIFF
--- a/src/engines/lazy-cautious-inference-engine.ts
+++ b/src/engines/lazy-cautious-inference-engine.ts
@@ -15,6 +15,7 @@ import { evaluate } from './evaluation'
 import { getNetworkInfo, initializeCliques, initializeEvidence, initializeNodeParents, initializeNodes, initializePosteriorCliquePotentials, initializePosteriorNodePotentials, initializePriorNodePotentials, initializeSeparatorPotentials, NetworkInfo, upsertFormula, setDistribution } from './util'
 import { Distribution } from './Distribution'
 import { arbitraryJoin, inferArbitraryJointProbability } from './arbitrary-join'
+import { getRandomSample } from './random-sample'
 
 /** This inference engine uses a modified version of the lazy cautious message
  * propigation strategy described in:
@@ -353,6 +354,22 @@ export class LazyPropagationEngine implements IInferenceEngine {
       })
     })
     return result
+  }
+
+  /** Get a random sample from the Bayes Network subject to any
+   * of the currently provided evidence.
+   * @param size: The sample size to return.
+   * Note: This function will throw an error if the sample size
+   *  is less than zero, or if the Bayes network posterior
+   *  distributions cannot be computed, or if the network is
+   *  otherwise ill formed.
+   */
+  getRandomSample (size: number): Record<string, string>[] {
+    // Some sanity checks
+    if (size < 0) throw new Error('Cannot generate random sample.   Sample size must be greater than zero.')
+    if (size === 0) return []
+    // ensure that all the clique potentials have been computed.
+    return getRandomSample(this, size)
   }
 
   // This is a back door for obtaining all the private collections in the inference engine.

--- a/src/engines/random-sample.ts
+++ b/src/engines/random-sample.ts
@@ -1,0 +1,195 @@
+import { FastPotential, combinationToIndex, indexToCombination } from './FastPotential'
+import { InferenceEngine } from '..'
+import { product, partition } from 'ramda'
+import { evaluateMarginalPure } from './evaluation'
+import { normalize } from './util'
+import { FastClique } from './FastClique'
+import { FastNode } from './FastNode'
+import { Formula } from './Formula'
+
+/** A CliqueInfo object is collection of information about a
+ * clique that facilitates efficient random sampling of that
+ * clique's variables.
+ */
+type CliqueInfo = {
+  /** The ordinal position of the clique in the Bayes Network's cliques collection. */
+  id: number;
+  /** The identifiers for the nodes that belong to the clique.  This collection is
+   * ordered such that the first n elements are the head variables of the clique's
+   * conditional distribution.
+   */
+  domain: number[];
+  /** The names of the variables in the clique.   This list is ordered in the same
+   * order as the domain.
+   */
+  nodeNames: string[];
+  /** The number of head variables in the clique's conditional distribution */
+  numberOfHeadVariables: number;
+  /** The number of levels of each of the variables in the clique's domain.  This
+   * list is ordered in the same order as the domain.
+   */
+  numbersOfLevels: number[];
+  /** The levels of each variable that occurs in the clique's domain.   This list is
+   * ordered first by variable, then by level.
+   */
+  levels: string[][];
+  /** The number of rows in each block of the clique's conditional probability
+   * distribution
+   */
+  blockSize: number;
+  /** The conditional probability distribution for the clique */
+  conditional: FastPotential;
+}
+
+/** Given a clique, collect the information necessary to generate
+ * random observations from the clique.   Specifically, we need to
+ * refactor the clique's posterior joint probability distribution,
+ * P(X) to a conditional probability distribution P(X - Y| Y) where
+ * the parent variables are chosen to be any of the variables
+ * which are members of any previously visited clique in the
+ * traversal ordering.
+ * @param clique: The clique of interest
+ * @param nodes: The nodes of the original Bayes Network
+ * @param potentials: The posterior (consistent) potentials of the
+ *   Bayes Network
+ * @param formulas: The collection of symbolic representations of
+ *   each of the posterior distributions in the network.
+ * @param visitedNodes: A collection of node identifiers for those
+ *   nodes which belong to one or more of the cliques that have
+ *   already been visited.
+  */
+function getCliqueInfo (clique: FastClique, nodes: FastNode[], potentials: (FastPotential|null)[], formulas: Formula[], visitedNodes: number[]): CliqueInfo {
+  const { domain: formulaDomain } = formulas[clique.posterior]
+  const [headVariables, parentVariables] = partition(x => !visitedNodes.includes(x), formulaDomain)
+  if (headVariables.length === 0) throw new Error('Cannot generate random sample.  Clique has no head variables.')
+  const domain = headVariables.concat(parentVariables)
+  const numbersOfLevels = domain.map(i => nodes[i].levels.length)
+  if (numbersOfLevels.some(x => x === 0)) throw new Error('Cannot generate random sample.  Some of the variables have no levels.')
+
+  const numberOfHeadVariables = headVariables.length
+  const parents: number[] = domain.filter(x => !headVariables.includes(x))
+
+  // construct the conditional distribution for the clique from the posterior
+  // joint probability distribution.
+  const posterior = potentials[clique.posterior] as FastPotential
+  const blockSize = product(numbersOfLevels.slice(0, numberOfHeadVariables))
+  // compute the potential of the parents by marginalizing the posterior joint
+  // probability distribution.
+  const parentPotential = evaluateMarginalPure(posterior, domain, numbersOfLevels, parents, numbersOfLevels.slice(numberOfHeadVariables), blockSize, true)
+
+  let conditional: FastPotential = []
+  for (let offset = 0; offset * blockSize < posterior.length; offset++) {
+    // We proceed block by block of the conditional distribution, ensuring that
+    // each block is normalized and satisifies P(X|Y) = P(X,Y) / P(Y).
+    const block = posterior.slice(offset * blockSize, (offset + 1) * blockSize)
+    conditional = conditional.concat(normalize(block.map((p) => p / parentPotential[offset])))
+  }
+
+  return {
+    id: clique.id,
+    domain,
+    nodeNames: domain.map(i => nodes[i].name),
+    numberOfHeadVariables,
+    numbersOfLevels,
+    levels: domain.map(i => nodes[i].levels),
+    blockSize,
+    conditional,
+  }
+}
+
+/** Aggregate the information about each clique and determine a
+ * forward traversal order that can be used for the generation of
+ * random samples.
+ * @param engine: The inference engine containing the Bayes Network
+ *   of interest.
+ * @returns: A list of clique information objects in ascending
+ *   traversal order.
+ */
+function getTraversalOrder (engine: InferenceEngine): CliqueInfo[] {
+  // deconstruct the inference engine to facilitate working with
+  // the hidden parameters.
+  const { _cliques, _potentials, _nodes, _connectedComponents, _formulas } = engine.toJSON()
+  // Perform a topological sorting on each of the connected components
+  // of the clique graph (junction tree graph), choosing an arbitrary
+  // clique from the connected connected components and peforming a
+  // depth first search starting from that clique.
+
+  const result: CliqueInfo[] = []
+  _connectedComponents.forEach(cliques => {
+    // keep track of the cliques that have been visited to prevent
+    // infinite looping.
+    const visitedCliques: number[] = []
+    let visitedNodes: number[] = []
+    // pick a root clique and initialize the queue.
+    let queue = [cliques[0]]
+    while (queue.length > 0) {
+      const cliqueId = queue.shift() as number
+      const clique: FastClique = _cliques[cliqueId]
+      const info = getCliqueInfo(clique, _nodes, _potentials, _formulas, visitedNodes)
+      visitedCliques.push(cliqueId)
+      visitedNodes = visitedNodes.concat(info.domain.slice(0, info.numberOfHeadVariables))
+      result.push(info)
+
+      queue = queue.concat(clique.neighbors.filter(x => !visitedCliques.includes(x)))
+    }
+  })
+  return result
+}
+
+function getRandomIndex (block: FastPotential): number {
+  let r = Math.random()
+  for (let i = 0; i < block.length; i++) {
+    // if this level is the one randomly selected, then return it.
+    if (r <= block[i]) return i
+    // otherwise, decrease the random value by the probability of this level
+    // and move on to the next level for the head variable.
+    r -= block[i]
+  }
+  // We should not be able to get here, but if we do, then return the last
+  // level for the head variable.
+  return block.length - 1
+}
+
+function getRandomObservation (cliqueInfo: CliqueInfo[]): Record<string, string> {
+  const fastObservation: Record<number, number> = {}
+  const result: Record<string, string> = {}
+  cliqueInfo.forEach(({ domain, numberOfHeadVariables, numbersOfLevels, levels, blockSize, conditional, nodeNames }) => {
+    const parentCombo = domain.slice(numberOfHeadVariables).map(i => fastObservation[i])
+    const offset = combinationToIndex(parentCombo, numbersOfLevels.slice(numberOfHeadVariables))
+    const block = conditional.slice(offset * blockSize, (offset + 1) * blockSize)
+    const headIdx = getRandomIndex(block)
+    const headCombo = indexToCombination(headIdx, numbersOfLevels.slice(0, numberOfHeadVariables))
+    headCombo.forEach((lvlIdx, headIdx) => {
+      const nodeIdx = domain[headIdx]
+      const nodeName = nodeNames[headIdx]
+      fastObservation[nodeIdx] = lvlIdx
+      result[nodeName] = levels[headIdx][lvlIdx]
+    })
+  })
+
+  return result
+}
+
+/** Generate a random sample from a Bayes network such that it
+ * reflects any of the currently provided evidence.   This method
+ * uses a variation on forward prior sampling, where we traverse
+ * the clique graph (rather than the Bayes Network itself).  This
+ * ensures that evidence is propigated to all nodes which are
+ * d-connected.
+ * @param engine: The inference engine containing the Bayes Network
+ *   to sample
+ * @param sampleSize: The number of observations in the requested
+ *   sample.
+ * Note: This function will throw an error if the posterior
+ *   clique distributions cannot be computed, the sample size is
+ *   less than zero, or if any of nodes have no levels.
+ */
+export function getRandomSample (engine: InferenceEngine, sampleSize: number): Record<string, string>[] {
+  // Basic sanity checks
+  if (sampleSize < 0) throw new Error('Cannot generate random sample.   Sample size must be greater than zero.')
+  if (sampleSize === 0) return []
+  // Force the computation of all the posterior joint distributions for the cliques
+  engine.inferAll()
+  const cliqueInfo: CliqueInfo[] = getTraversalOrder(engine)
+  return Array(sampleSize).fill(null).map(() => getRandomObservation(cliqueInfo))
+}

--- a/src/engines/util.ts
+++ b/src/engines/util.ts
@@ -500,3 +500,15 @@ export function restoreEngine (engine: InferenceEngine, localPotentials: (FastPo
   Object.assign(engine, { _potentials: potentials })
   engine.setEvidence(evidence)
 }
+
+/** Given a potential function, normalize the potentials so that they
+ * total to unity.
+ * @param potentials: the potential function to normalize.
+ * Note: This function may fail to produce a valid potential function
+ * if the input contains NaN or infinite values, or if the sum of the
+ * potentials is zero.   The caller must guard against these conditions.
+ */
+export function normalize (potentials: FastPotential) {
+  const total = sum(potentials)
+  return potentials.map(p => p / total)
+}

--- a/test/sampling/getRandomSample.test.ts
+++ b/test/sampling/getRandomSample.test.ts
@@ -1,0 +1,77 @@
+
+import { network } from '../../models/alarm'
+import { InferenceEngine, FastPotential } from '../../src'
+import { groupDataByObservedValues } from '../../src/learning/Observation'
+import { indexToCombination } from '../../src/engines'
+import { product } from 'ramda'
+
+describe('getRandomSample', () => {
+  it('returns an empty sample when requested', () => {
+    const engine = new InferenceEngine(network)
+    const result: Record<string, string>[] = engine.getRandomSample(0)
+    expect(result).toEqual([])
+  })
+  it('throws when a negative sample size is requested', () => {
+    const engine = new InferenceEngine(network)
+    expect(() => engine.getRandomSample(-1)).toThrow()
+  })
+  it('sample contains the correct number of observations', () => {
+    const engine = new InferenceEngine(network)
+    const n = Math.floor(Math.random() * 1000)
+    const result = engine.getRandomSample(n)
+    expect(result.length).toEqual(n)
+  })
+  it('each observation has a level for each variable', () => {
+    const engine = new InferenceEngine(network)
+    const variables = engine.getVariables()
+    const n = 1
+    const result = engine.getRandomSample(n)
+    const expected = result.map(x => variables.every(name => x[name] != null))
+    expect(expected).toEqual(Array(n).fill(true))
+  })
+  it('is consistent with any provided evidence', () => {
+    const engine = new InferenceEngine(network)
+    engine.setEvidence({ ALARM: ['T'] })
+    const n = 100
+    const result = engine.getRandomSample(n)
+    const str = 'ALARM'
+    expect(result.every(x => x[str] === 'T')).toEqual(true)
+  })
+  it('approximates the joint distribution', () => {
+    const engine = new InferenceEngine(network)
+    const n = 10000
+    const result = engine.getRandomSample(n)
+    const groupedData = groupDataByObservedValues(result, engine)
+    const variableNames = engine.getVariables()
+    const dist = engine.getJointDistribution(variableNames, [])
+    const variableLevels = variableNames.map(name => engine.getLevels(name))
+    const numbersOfHeadLevels = variableNames.map(name => engine.getLevels(name).length)
+    const observed: FastPotential = Array(product(numbersOfHeadLevels)).fill(null).map((_, idx) => {
+      const combo = indexToCombination(idx, numbersOfHeadLevels)
+      const group = groupedData.filter(x => combo.every((lvl, varIdx) => x.evidence[variableNames[varIdx]][0] === variableLevels[varIdx][lvl]))
+      return (group.length === 0) ? 0 : group[0].frequency
+    })
+    const expected = dist.getPotentials().map(p => Number.isNaN(p) ? 0 : p)
+    const residuals = observed.map((x, i) => Math.abs(x - expected[i]))
+    expect(residuals.every(p => p < 0.01)).toEqual(true)
+  })
+  it('approximates the joint distribution with evidence', () => {
+    const engine = new InferenceEngine(network)
+    engine.setEvidence({ ALARM: ['T'] })
+    const n = 10000
+    const result = engine.getRandomSample(n)
+    const groupedData = groupDataByObservedValues(result, engine)
+    const variableNames = engine.getVariables()
+    const dist = engine.getJointDistribution(variableNames, [])
+    const variableLevels = variableNames.map(name => engine.getLevels(name))
+    const numbersOfHeadLevels = variableNames.map(name => engine.getLevels(name).length)
+    const observed: FastPotential = Array(product(numbersOfHeadLevels)).fill(null).map((_, idx) => {
+      const combo = indexToCombination(idx, numbersOfHeadLevels)
+      const group = groupedData.filter(x => combo.every((lvl, varIdx) => x.evidence[variableNames[varIdx]][0] === variableLevels[varIdx][lvl]))
+      return (group.length === 0) ? 0 : group[0].frequency
+    })
+    const expected = dist.getPotentials().map(p => Number.isNaN(p) ? 0 : p)
+    const residuals = observed.map((x, i) => Math.abs(x - expected[i]))
+    expect(residuals.every(p => p < 0.01)).toEqual(true)
+  })
+})


### PR DESCRIPTION
#### What does this PR do?
adds a new method to the inference engine object that can be used to generate random samples from the Bayes Network while respecting the provided evidence.   The algorithm performs a forward prior sampling, but does so over the clique graph so that no additional steps are required to make the resulting samples consistent.

#### Where should the reviewer start?
The lazy-cautious-inference-engine.ts module contains the entry point for this new functionality.   This is a good place to start.   The implementation is in the random-sampling.ts module, and contains complete details for the algorithm.

#### What testing has been done on this PR?
Unit tests to ensure the basic functionality have been implemented.   Additional manual add-hoc testing has also been performed.

#### How should this be manually tested?
Create a new inference engine and then run the "getRandomSamples" method.

#### Any background context you want to provide?
This implementation is based on Markov chain sampling, https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo, but has been extended to support both hard and soft evidence.
