### PR TITLE
random sampling has nan in conditional probabilities

### DIFF
--- a/models/fourNode.ts
+++ b/models/fourNode.ts
@@ -1,0 +1,57 @@
+import { INode, ICptWithParents, ICptWithoutParents } from '../src/types'
+
+export const B: INode = {
+  id: 'B',
+  states: ['T', 'F'],
+  parents: [],
+  cpt: { T: 0.01, F: 0.98 },
+}
+
+export const I: INode = {
+  id: 'I',
+  states: ['-1', '0', '1'],
+  parents: ['B'],
+  cpt: [
+    { when: { B: 'T' }, then: { '-1': 0.85, 0: 0.10, 1: 0.5 } },
+    { when: { B: 'F' }, then: { '-1': 0.15, 0: 0.30, 1: 0.65 } },
+  ],
+}
+
+export const F: INode = {
+  id: 'F',
+  states: ['-0.5', '0', '0.5'],
+  parents: ['B'],
+  cpt: [
+    { when: { B: 'T' }, then: { '-0.5': 0.85, 0: 0.10, 0.5: 0.5 } },
+    { when: { B: 'F' }, then: { '-0.5': 0.15, 0: 0.30, 0.5: 0.65 } },
+  ],
+}
+
+export const S: INode = {
+  id: 'S',
+  states: ['A', 'B', 'C'],
+  parents: ['I', 'F'],
+  cpt: [
+    { when: { I: '-1', F: '-0.5' }, then: { A: 0.85, B: 0.10, C: 0.05 } },
+    { when: { I: '0', F: '-0.5' }, then: { A: 0.10, B: 0.05, C: 0.85 } },
+    { when: { I: '1', F: '-0.5' }, then: { A: 0.05, B: 0.85, C: 0.1 } },
+
+    { when: { I: '-1', F: '0' }, then: { A: 0.85, B: 0.05, C: 0.10 } },
+    { when: { I: '0', F: '0' }, then: { A: 0.05, B: 0.10, C: 0.85 } },
+    { when: { I: '1', F: '0' }, then: { A: 0.1, B: 0.85, C: 0.05 } },
+
+    { when: { I: '-1', F: '0.5' }, then: { A: 0.10, B: 0.85, C: 0.5 } },
+    { when: { I: '0', F: '0.5' }, then: { A: 0.85, B: 0.05, C: 0.1 } },
+    { when: { I: '1', F: '0.5' }, then: { A: 0.05, B: 0.10, C: 0.85 } },
+  ],
+}
+
+export const allNodes = [B, F, I, S]
+export const network: { [name: string]: { levels: string[]; parents: string[]; cpt?: ICptWithParents | ICptWithoutParents}} = {}
+allNodes.forEach((node: INode) => {
+  network[node.id] = {
+    levels: node.states,
+    parents: node.parents,
+    cpt: node.cpt,
+  }
+})

--- a/src/engines/random-sample.ts
+++ b/src/engines/random-sample.ts
@@ -78,7 +78,8 @@ function getCliqueInfo (clique: FastClique, nodes: FastNode[], potentials: (Fast
   // compute the potential of the parents by marginalizing the posterior joint
   // probability distribution.
   const parentNumOfLvls = numbersOfLevels.slice(numberOfHeadVariables)
-  const parentPotential = evaluateMarginalPure(posterior, posteriorDomain, posteriorNumLvls, parents, parentNumOfLvls, product(parentNumOfLvls), false)
+  const parentSize = product(parentNumOfLvls)
+  const parentPotential = evaluateMarginalPure(posterior, posteriorDomain, posteriorNumLvls, parents, parentNumOfLvls, parentSize, false)
 
   let conditional: FastPotential = []
   for (let offset = 0; offset * blockSize < posterior.length; offset++) {

--- a/src/engines/random-sample.ts
+++ b/src/engines/random-sample.ts
@@ -72,10 +72,13 @@ function getCliqueInfo (clique: FastClique, nodes: FastNode[], potentials: (Fast
   // construct the conditional distribution for the clique from the posterior
   // joint probability distribution.
   const posterior = potentials[clique.posterior] as FastPotential
+  const posteriorDomain = formulas[clique.posterior].domain
+  const posteriorNumLvls = posteriorDomain.map(x => nodes[x].levels.length)
   const blockSize = product(numbersOfLevels.slice(0, numberOfHeadVariables))
   // compute the potential of the parents by marginalizing the posterior joint
   // probability distribution.
-  const parentPotential = evaluateMarginalPure(posterior, domain, numbersOfLevels, parents, numbersOfLevels.slice(numberOfHeadVariables), blockSize, true)
+  const parentNumOfLvls = numbersOfLevels.slice(numberOfHeadVariables)
+  const parentPotential = evaluateMarginalPure(posterior, posteriorDomain, posteriorNumLvls, parents, parentNumOfLvls, product(parentNumOfLvls), false)
 
   let conditional: FastPotential = []
   for (let offset = 0; offset * blockSize < posterior.length; offset++) {

--- a/test/sampling/getRandomSample.test.ts
+++ b/test/sampling/getRandomSample.test.ts
@@ -37,6 +37,13 @@ describe('getRandomSample', () => {
     const str = 'ALARM'
     expect(result.every(x => x[str] === 'T')).toEqual(true)
   })
+  it('is consistent when evidence is provided for all variables', () => {
+    const engine = new InferenceEngine(network)
+    engine.setEvidence({ ALARM: ['F'], EARTHQUAKE: ['F'], BURGLARY: ['F'], JOHN_CALLS: ['F'], MARY_CALLS: ['F'] })
+    const n = 100
+    const result = engine.getRandomSample(n)
+    expect(result.every(xs => Object.values(xs).every(x => x === 'F'))).toEqual(true)
+  })
   it('approximates the joint distribution', () => {
     const engine = new InferenceEngine(network)
     const n = 10000

--- a/test/sampling/getRandomSample.test.ts
+++ b/test/sampling/getRandomSample.test.ts
@@ -1,5 +1,6 @@
 
 import { network } from '../../models/alarm'
+import { network as net4 } from '../../models/fourNode'
 import { InferenceEngine, FastPotential } from '../../src'
 import { groupDataByObservedValues } from '../../src/learning/Observation'
 import { indexToCombination } from '../../src/engines'
@@ -38,11 +39,13 @@ describe('getRandomSample', () => {
     expect(result.every(x => x[str] === 'T')).toEqual(true)
   })
   it('is consistent when evidence is provided for all variables', () => {
-    const engine = new InferenceEngine(network)
-    engine.setEvidence({ ALARM: ['F'], EARTHQUAKE: ['F'], BURGLARY: ['F'], JOHN_CALLS: ['F'], MARY_CALLS: ['F'] })
+    const engine = new InferenceEngine(net4)
+    const evidence = { B: ['T'], F: ['0'], I: ['0'], S: ['B'] }
+    const expected = { B: 'T', F: '0', I: '0', S: 'B' }
+    engine.setEvidence(evidence)
     const n = 100
     const result = engine.getRandomSample(n)
-    expect(result.every(xs => Object.values(xs).every(x => x === 'F'))).toEqual(true)
+    result.forEach(observed => expect(observed).toEqual(expected))
   })
   it('approximates the joint distribution', () => {
     const engine = new InferenceEngine(network)


### PR DESCRIPTION
What does this PR do?
When random sampling from the "fourNode" example network where evidence has been provided for all the nodes, the sample ends up inconsistent with the provided evidence. This appears to have resulted from the wrong size being used for the parent potential function -- As the array was populated, the array was automatically expanded to accommodate the new data, however the new elements were initialized with NaN. The NaNs propagated into the conditional distribution, throwing off the termination condition for the prior sampling algorithm. As a result, the "random" value for node "S" was always the last level, instead of the second level as expected.

Where should the reviewer start?
The random-sample.ts file contains the relevant change, and is a good place to start.

What testing has been done on this PR?
A unit test has been added to verify the correct behavior and prevent regression.

How should this be manually tested?
Try random sampling with evidence on other networks of interest.

Any background context you want to provide?
The random sampling algorithm uses a variation of prior sampling, which traverses the junction tree graph in breadth first order rather than traversing the Bayes network. For each clique, we use the posterior clique distribution (as generated by the lazy inference engine) which contains the joint distribution over the variables in the clique. We divide this by the joint distribution over the variables in the separation set between the current node and its parent ( as defined in the traversal order). This yields a probability distribution for the variables that are in the clique but not in the parent conditioned on the parent variables. Given the random selections for the parents, we can find the correct block of the conditional distribution, and use "prior distribution sampling" to simultaneously select values for all the head variables of the distribution.

The sampling algorithm marginalizes the joint distribution over the clique to obtain distribution over the variables in the separation set. It is the marginalization that was failing, resulting in NaN values in both the parent probability and conditional distribution. Since (r > NaN) is always false regardless of the value for r, the random sampling always failed to find a random value in the block of the conditional distribution, and defaulted to returning the last level(s) of the head variable(s).

What are the relevant issues?
Screenshots (if appropriate)