### PR TITLE
fix(util): fix pick root clique function

### DIFF
--- a/src/engines/util.ts
+++ b/src/engines/util.ts
@@ -550,7 +550,7 @@ export function pickRootClique (cliques: FastClique[], joinDomain: number[], for
     if (sizeA !== sizeB) return sizeA - sizeB
     // If they have the same size domain, pick the one with the fewest neighbors
     const [neighborsA, neighborsB] = [a, b].map(x => x.neighbors.length)
-    if (sizeA !== sizeB) return neighborsA - neighborsB
+    if (neighborsA !== neighborsB) return neighborsA - neighborsB
     // Of those, pick the one with the smaller id.
     const [idA, idB] = [a, b].map(x => x.id)
     return idA - idB


### PR DESCRIPTION
#### What does this PR do?
The pickRootClique function is responsible for choosing the best clique for collecting
information for an arbitrary joint distribution.    The previous implementation ignored the 
comparison on the number of neighbors, and instead compared based on the size of the
two cliques.   This could result in suboptimal performance.    This one line change fixes the
problem. 

#### Where should the reviewer start?
The pickRootClique function

#### What testing has been done on this PR?
All existing unit tests

#### What are the relevant issues?
MA-284
