### PR TITLE
Replace Naive Summation with Kahan Summation

### DIFF
--- a/src/engines/Distribution.ts
+++ b/src/engines/Distribution.ts
@@ -1,8 +1,8 @@
 import { FastPotential, combinationToIndex, indexToCombination } from './FastPotential'
-import { product, uniq, sum, max } from 'ramda'
+import { product, uniq, max } from 'ramda'
 import { evaluateMarginalPure } from './evaluation'
 import { ICptWithParents, ICptWithoutParents } from '../types'
-import { commaSep } from './util'
+import { commaSep, kahanSum } from './util'
 
 /** A Distribution represents a joint distribution of one (trivially) or more
    * "head" variables, optionally conditioned upon one or more parent variables.
@@ -245,7 +245,7 @@ export class Distribution {
     const blocksize = product(numberOfLevels.slice(0, this._numberOfHeadVariables))
     let total = 0
     for (let i = 0; i < potentials.length; i += blocksize) {
-      const subtotal = sum(potentials.slice(i, i + blocksize))
+      const subtotal = kahanSum(potentials.slice(i, i + blocksize))
       if (subtotal === 0) throw new Error('Cannot set the potentials for the distribution.  The probabilities are undefined for some combinations of the parent varaibles')
       total += subtotal
     }
@@ -346,7 +346,7 @@ export class Distribution {
       const newIndex = combinationToIndex(oldCombos, newNumberOfLevels)
       potentialFunction[newIndex] = v
     })
-    const total = sum(potentialFunction)
+    const total = kahanSum(potentialFunction)
 
     this._variableLevels = variableLevels
     this._potentialFunction = potentialFunction.map(p => p / total)

--- a/src/engines/evaluate-join-potential.ts
+++ b/src/engines/evaluate-join-potential.ts
@@ -4,7 +4,7 @@ import { evaluate, evaluateMarginalPure } from './evaluation'
 import { FastClique } from './FastClique'
 import { Formula } from './Formula'
 import { FastPotential } from './FastPotential'
-import { sum } from 'ramda'
+import { kahanSum } from './util'
 
 /** Construct the join of an arbitrary collection of variables in a Bayesian Network,
  * conditioned on an optional set of parent variables.  Returns the potential function
@@ -58,7 +58,7 @@ export function evaluateJoinPotentials (nodes: FastNode[], cliques: FastClique[]
   // that they sum to unity.
   let result: FastPotential = []
   if (joinFormula.domain.every((n, i) => n === joinDomain[i])) {
-    const total = sum(joinPotentials)
+    const total = kahanSum(joinPotentials)
     result = joinPotentials.map(p => total !== 0 ? p / total : p)
   } else {
     result = evaluateMarginalPure(joinPotentials, joinFormula.domain, joinFormula.domain.map(i => nodes[i].levels.length), joinDomain, joinDomain.map(i => nodes[i].levels.length), joinPotentials.length, true)

--- a/src/engines/evaluate-join-probability.ts
+++ b/src/engines/evaluate-join-probability.ts
@@ -1,10 +1,11 @@
 import { FastPotential, indexToCombination } from './FastPotential'
 import { FastClique } from './FastClique'
 import { Formula, FormulaType, Product, Marginal, Reference, NodePotential } from './Formula'
-import { sum, intersection, product, union } from 'ramda'
+import { intersection, product, union } from 'ramda'
 import { evaluateMarginalPure, evaluateProductPure, evaluate } from './evaluation'
 import { FastNode } from './FastNode'
 import { propagateJoinMessages } from './join-propagation'
+import { kahanSum } from './util'
 
 /** This is a special case algorithm for computing a joint probability when there
  * is no evidence.   This algorithm relies upon a formula evaluation method that
@@ -47,7 +48,7 @@ export function inferJoinProbability (nodes: FastNode[], cliques: FastClique[], 
   })
   // finally, return the result of the join and the supplementary information
   return {
-    joinProbability: sum(joinPotentials),
+    joinProbability: kahanSum(joinPotentials),
     supplementalFormulas,
     supplementalPotentials,
   }

--- a/src/engines/lazy-cautious-inference-engine.ts
+++ b/src/engines/lazy-cautious-inference-engine.ts
@@ -12,7 +12,7 @@ import { NodeId, FormulaId, FastEvent } from './common'
 import { Formula, EvidenceFunction, updateReferences } from './Formula'
 import { propagatePotentials } from './symbolic-propagation'
 import { evaluate } from './evaluation'
-import { getNetworkInfo, initializeCliques, initializeEvidence, initializeNodeParents, initializeNodes, initializePosteriorCliquePotentials, initializePosteriorNodePotentials, initializePriorNodePotentials, initializeSeparatorPotentials, NetworkInfo, upsertFormula, setDistribution, pickRootClique } from './util'
+import { getNetworkInfo, initializeCliques, initializeEvidence, initializeNodeParents, initializeNodes, initializePosteriorCliquePotentials, initializePosteriorNodePotentials, initializePriorNodePotentials, initializeSeparatorPotentials, NetworkInfo, upsertFormula, setDistribution, pickRootClique, kahanSum } from './util'
 import { Distribution } from './Distribution'
 import { evaluateJoinPotentials } from './evaluate-join-potential'
 import { inferJoinProbability } from './evaluate-join-probability'
@@ -280,7 +280,7 @@ export class LazyPropagationEngine implements IInferenceEngine {
    */
   private inferFromMarginal (nodeId: NodeId, levels: number[]): number {
     const p = evaluate(this._nodes[nodeId].posteriorMarginal, this._nodes, this._formulas, this._potentials)
-    return levels.reduce((acc, level) => acc + p[level], 0)
+    return kahanSum(levels.map((level) => p[level]))
   }
 
   /**

--- a/src/engines/util.ts
+++ b/src/engines/util.ts
@@ -557,3 +557,27 @@ export function pickRootClique (cliques: FastClique[], joinDomain: number[], for
   })
   return sortedCliques[0]
 }
+
+/**
+ * Perform summation with compensation to compute the total of a list of
+ * numeric values while minimizing floating point error.
+ * @param list - The list of values to sum
+ */
+export function kahanSum (list: number[]): number {
+  // initialize the accumulator and the compensation
+  let total = 0
+  let carry = 0
+  for (let i = 0; i < list.length; i++) {
+    // Compute the compensated value to add to the total
+    const y = list[i] - carry
+    // Add the compensated value, however the low order digits
+    // of y will be lost
+    const t = total + y
+    // Recover the low order digits that were lost.  Note that
+    // the parenthesis are important and cannot be removed without
+    // changing the result.
+    carry = (t - total) - y
+    total = t
+  }
+  return total
+}

--- a/src/inferences/junctionTree/propagate-potentials.ts
+++ b/src/inferences/junctionTree/propagate-potentials.ts
@@ -24,12 +24,12 @@ import {
   pipe,
   prop,
   reduce,
-  sum,
 } from 'ramda'
 import {
   buildCombinations,
   objectEqualsByFirstObjectKeys,
 } from '../../utils'
+import { kahanSum } from '../../engines/util'
 
 interface ICollectEvidenceOrder {
   id: string;
@@ -72,7 +72,7 @@ const createMessagesByCliques: (cliques: IClique[]) => ICliquePotentialMessages 
 export const marginalizePotentials = (network: INetwork, sepSet: string[], potentials: ICliquePotentialItem[]): ICliquePotentialItem[] =>
   reduce(
     (acc, cpt) => {
-      const then = sum(
+      const then = kahanSum(
         potentials
           .filter(potential => objectEqualsByFirstObjectKeys(cpt.when, potential.when))
           .map(prop('then')),

--- a/src/inferences/variableElimination.ts
+++ b/src/inferences/variableElimination.ts
@@ -8,6 +8,7 @@ import {
   INetwork,
   INode,
 } from '../types'
+import { kahanSum } from '../engines/util'
 
 function buildFactor (node: INode, giving?: ICombinations): IFactor {
   const factor = []
@@ -123,7 +124,7 @@ function eliminateVariable (factor: IFactor, variable: string): IFactor {
 }
 
 function normalizeFactor (factor: IFactor): IFactor {
-  const total = factor.reduce((acc, row) => acc + row.value, 0)
+  const total = kahanSum(factor.map((row) => row.value))
 
   if (total === 0) {
     return factor

--- a/src/learning/line-search.ts
+++ b/src/learning/line-search.ts
@@ -4,7 +4,7 @@ import { StepResult, StepStatus } from './StepResult'
 import { newtonStep } from './newton-step'
 import { ObjectiveFunction } from './objective-functions/ObjectiveFunction'
 import { SQRTEPS, CUBEROOTEPS } from './vector-utils'
-import { restoreEngine } from '../engines/util'
+import { restoreEngine, kahanSum } from '../engines/util'
 
 const ALPHA = CUBEROOTEPS
 const BETA = 0.9
@@ -85,7 +85,7 @@ export function lineSearch (engine: InferenceEngine, current: TowerOfDerivatives
   // the maximum step size allowed by the algorithm.   This is a first attempt at scaling the
   // step size based on the size of the network.   I am scaling it so that the max step size is a
   // multiple of the sum of the number of blocks in each conditional distribution
-  const MAXSTEPSIZE = 0.5 * current.xs.reduce((acc, ps, i) => acc + ps.length / numbersOfHeadLevels[i], 0)
+  const MAXSTEPSIZE = 0.5 * kahanSum(current.xs.map((ps, i) => ps.length / numbersOfHeadLevels[i]))
   const MAXLAMBDA = (current.ascentDirectionMagnitude > MAXSTEPSIZE) ? 1 : MAXSTEPSIZE / current.ascentDirectionMagnitude
   const MINLAMBDA = tolerance / relativeLength(current)
   const MAXITERATIONS = 100

--- a/src/learning/vector-utils.ts
+++ b/src/learning/vector-utils.ts
@@ -1,5 +1,5 @@
 import { FastPotential } from '..'
-import { sum } from 'ramda'
+import { kahanSum } from '../engines/util'
 
 export const CUBEROOTEPS = Math.pow(Number.EPSILON, 1 / 3)
 export const SQRTEPS = Math.sqrt(Number.EPSILON)
@@ -11,7 +11,7 @@ export const SQRTEPS = Math.sqrt(Number.EPSILON)
  *    its parents.
  */
 export function norm2 (potentials: FastPotential[]): number {
-  return Math.sqrt(sum(potentials.map(ps => sum(ps.map(p => p * p)))))
+  return Math.sqrt(kahanSum(potentials.map(ps => kahanSum(ps.map(p => p * p)))))
 }
 
 /** Compute the condition number for a Hessian matrix.   Larger
@@ -111,8 +111,8 @@ export function LagrangianMultipliers (gradient: FastPotential[], hessian: FastP
     for (let jk = 0; jk < grad.length; jk += n) {
       const gslice = grad.slice(jk, jk + n)
       const hslice = hess.slice(jk, jk + n)
-      const numerator = gslice.reduce((acc, g, k) => acc + g * hslice[k], 0)
-      const denominator = sum(hslice)
+      const numerator = kahanSum(gslice.map((g, k) => g * hslice[k]))
+      const denominator = kahanSum(hslice)
       gs.push(numerator / denominator)
     }
     gammas.push(gs)

--- a/test/inference-engines/non-binary-distribution.test.ts
+++ b/test/inference-engines/non-binary-distribution.test.ts
@@ -91,7 +91,7 @@ describe('inference on non-binary-distribution', () => {
     })
     it('infers the correct marginal for a  with 2 parents', () => {
       expect(toPrecision(engine.infer({ D: ['i'] }))).toEqual(0.2501)
-      expect(toPrecision(engine.infer({ D: ['j'] }))).toEqual(0.4327)
+      expect(toPrecision(engine.infer({ D: ['j'] }))).toEqual(0.4328)
       expect(toPrecision(engine.infer({ D: ['k'] }))).toEqual(0.3171)
     })
   })

--- a/test/utils/summation.test.ts
+++ b/test/utils/summation.test.ts
@@ -1,0 +1,12 @@
+import { kahanSum } from '../../src/engines/util'
+import { sum } from 'ramda'
+
+describe('kahanSummation', () => {
+  it('returns a more precise result', () => {
+    const xs = [1, Number.EPSILON, -Number.EPSILON, 1, Number.EPSILON, -Number.EPSILON]
+    const observed = kahanSum(xs)
+    expect(observed).toEqual(2)
+    expect(xs.reduce((a, b) => a + b, 0)).not.toEqual(2)
+    expect(sum(xs)).not.toEqual(2)
+  })
+})


### PR DESCRIPTION
#### What does this PR do?
The ramda sum operation performs naive summation operation, which can loose precision which will be worst case proportional to the number of elements in the list summed.   This PR replaces all occurrences of the sum operation, as well as additive reduce operations over arrays with a compensation summation algorithm. 

#### Where should the reviewer start?
Review the **kahanSummation** function in the utils.ts module.   This function implements the compensation summation algorithm.

#### What testing has been done on this PR?
Added a unit test to confirm the correct behavior of the compensation sum.   All other unit tests still pass (or have been modified to reflect the more accurate expected results).

#### How should this be manually tested?
Use the same manual testing strategy employed in previous pull requests.   

#### Any background context you want to provide?
For more information on compensation summation, consult: https://en.wikipedia.org/wiki/Kahan_summation_algorithm

#### What are the relevant issues?
MA-283
