### PR TITLE
Bugfix/random sample fails with for each of undefined error

### DIFF
--- a/test/sampling/getRandomSample.test.ts
+++ b/test/sampling/getRandomSample.test.ts
@@ -1,6 +1,7 @@
 
 import { network } from '../../models/alarm'
 import { network as net4 } from '../../models/fourNode'
+import { network as huge } from '../../models/huge-network'
 import { InferenceEngine, FastPotential } from '../../src'
 import { groupDataByObservedValues } from '../../src/learning/Observation'
 import { indexToCombination } from '../../src/engines'
@@ -83,5 +84,11 @@ describe('getRandomSample', () => {
     const expected = dist.getPotentials().map(p => Number.isNaN(p) ? 0 : p)
     const residuals = observed.map((x, i) => Math.abs(x - expected[i]))
     expect(residuals.every(p => p < 0.02)).toEqual(true)
+  })
+  it('works for very large networks', () => {
+    const engine = new InferenceEngine(huge)
+    const observed = engine.getRandomSample(100)
+    expect(observed.length).toEqual(100)
+    expect(observed.every(x => Object.keys(x).length === engine.getVariables().length)).toEqual(true)
   })
 })


### PR DESCRIPTION
This PR Fixes a bug with the random sampling for large Bayes networks.   Specifically, for some networks, the clique distributions may not be computed despite all the marginals being computed.    This causes a "Cannot call forEach of undefined"  error when trying to traverse the cliques in the Gaussian sampling algorithm.

This code introduces forces the computation of the clique potentials during gaussian sampling, and introduces a unit test to prevent regression