### PR TITLE
Bugfix/local distribution should not include evidence

### DIFF
--- a/test/inference-engines/getDistribution.test.ts
+++ b/test/inference-engines/getDistribution.test.ts
@@ -16,4 +16,16 @@ describe('getDistribution', () => {
     expect(observed.variableLevels).toEqual(expected.variableLevels)
     expect(observed.potentialFunction.map(x => x.toExponential(5))).toEqual(expected.potentialFunction.map(x => x.toExponential(5)))
   })
+  it('getDistribution is the prior local distribution', () => {
+    const engine = new InferenceEngine(network)
+    const name = 'node3'
+    engine.setEvidence({ node3: ['T'] })
+    const observed = engine.getDistribution(name).toJSON()
+    const cpt = network[name]?.cpt as ICptWithParents | ICptWithoutParents
+    const expected = fromCPT('node3', [], [['T', 'F']], cpt).toJSON()
+    expect(observed.numberOfHeadVariables).toEqual(expected.numberOfHeadVariables)
+    expect(observed.variableNames).toEqual(expected.variableNames)
+    expect(observed.variableLevels).toEqual(expected.variableLevels)
+    expect(observed.potentialFunction.map(x => x.toExponential(5))).toEqual(expected.potentialFunction.map(x => x.toExponential(5)))
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a bug in the getDistribution function.   The intent of the function is to get a distribution that contains the local distribution for the given variable.   This should be independent of any evidence that has been provided.    The previous implementation used the prior joint distribution for the variable, and therefore was subject to any evidence that was provided.

#### Where should the reviewer start?
The getDistribution function is the only method that has been touched.   It is the best place to start.

#### What testing has been done on this PR?
A new test has been added to ensure that the distribution returned is the local distribution for the variable, prior to message passing
